### PR TITLE
Configure travis to fake enough AWS SDK to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: scala
+env:
+  - AWS_REGION=eu-west-1


### PR DESCRIPTION
The dependency upon the AWS SDK causes the tests to fail unless the environment variable AWS_REGION is set. With all AWS credentials removed (i.e. `rm -r ~/.aws/`) and setting `AWS_REGION` the tests can pass.

N.B. Tests on Travis aren't passing due to a different issue to do with reading files from disk is a different order than the test expects.