### PR TITLE
[localfilestream] Compare test files within a Set

### DIFF
--- a/src/test/scala/net/kemitix/s3thorp/LocalFileStreamSuite.scala
+++ b/src/test/scala/net/kemitix/s3thorp/LocalFileStreamSuite.scala
@@ -1,5 +1,7 @@
 package net.kemitix.s3thorp
 
+import java.io.File
+
 import org.scalatest.FunSpec
 
 class LocalFileStreamSuite extends FunSpec with LocalFileStream {
@@ -8,7 +10,7 @@ class LocalFileStreamSuite extends FunSpec with LocalFileStream {
     var uploadResource = Resource(this, "upload")
     it("should find all files") {
       val result: Set[String] = streamDirectoryPaths(uploadResource).toSet
-          .map(x=>uploadResource.toPath.relativize(x.toPath).toString)
+          .map { x: File => uploadResource.toPath.relativize(x.toPath).toString }
       assertResult(Set("subdir/leaf-file", "root-file"))(result)
     }
   }

--- a/src/test/scala/net/kemitix/s3thorp/LocalFileStreamSuite.scala
+++ b/src/test/scala/net/kemitix/s3thorp/LocalFileStreamSuite.scala
@@ -7,9 +7,9 @@ class LocalFileStreamSuite extends FunSpec with LocalFileStream {
   describe("streamDirectoryPaths") {
     var uploadResource = Resource(this, "upload")
     it("should find all files") {
-      val result: List[String] = streamDirectoryPaths(uploadResource).toList
+      val result: Set[String] = streamDirectoryPaths(uploadResource).toSet
           .map(x=>uploadResource.toPath.relativize(x.toPath).toString)
-      assertResult(List("subdir/leaf-file", "root-file"))(result)
+      assertResult(Set("subdir/leaf-file", "root-file"))(result)
     }
   }
 }


### PR DESCRIPTION
Removes issue of files being read in different orders.

Fixes #10 