### PR TITLE
[core] MD5HashGenerator uses IO to return where there is file IO

### DIFF
--- a/aws-lib/src/test/scala/net/kemitix/s3thorp/aws/lib/MD5HashData.scala
+++ b/aws-lib/src/test/scala/net/kemitix/s3thorp/aws/lib/MD5HashData.scala
@@ -1,4 +1,4 @@
-package net.kemitix.s3thorp.core
+package net.kemitix.s3thorp.aws.lib
 
 import net.kemitix.s3thorp.domain.MD5Hash
 

--- a/aws-lib/src/test/scala/net/kemitix/s3thorp/aws/lib/S3ClientSuite.scala
+++ b/aws-lib/src/test/scala/net/kemitix/s3thorp/aws/lib/S3ClientSuite.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.s3.transfer.model.UploadResult
 import com.amazonaws.services.s3.transfer.{TransferManager, Upload}
 import net.kemitix.s3thorp.aws.api.S3Action.UploadS3Action
 import net.kemitix.s3thorp.aws.api.{S3Client, UploadProgressListener}
-import net.kemitix.s3thorp.core.MD5HashData.rootHash
+import net.kemitix.s3thorp.aws.lib.MD5HashData.rootHash
 import net.kemitix.s3thorp.core.{KeyGenerator, Resource, S3MetaDataEnricher}
 import net.kemitix.s3thorp.domain._
 import org.scalamock.scalatest.MockFactory
@@ -90,9 +90,10 @@ class S3ClientSuite
       val s3Client = new ThorpS3Client(amazonS3, amazonS3TransferManager)
 
       val prefix = RemoteKey("prefix")
-      val localFile: LocalFile = LocalFile.resolve("root-file", rootHash, source, KeyGenerator.generateKey(source, prefix))
-      val bucket: Bucket = Bucket("a-bucket")
-      val remoteKey: RemoteKey = RemoteKey("prefix/root-file")
+      val localFile =
+        LocalFile.resolve("root-file", rootHash, source, KeyGenerator.generateKey(source, prefix))
+      val bucket = Bucket("a-bucket")
+      val remoteKey = RemoteKey("prefix/root-file")
       val progressListener = new UploadProgressListener(localFile)
 
       val upload = stub[Upload]

--- a/aws-lib/src/test/scala/net/kemitix/s3thorp/aws/lib/S3ClientTransferManagerSuite.scala
+++ b/aws-lib/src/test/scala/net/kemitix/s3thorp/aws/lib/S3ClientTransferManagerSuite.scala
@@ -1,17 +1,13 @@
 package net.kemitix.s3thorp.aws.lib
 
-import java.io.File
 import java.time.Instant
 
-import com.amazonaws.AmazonClientException
-import com.amazonaws.event.ProgressListener
-import com.amazonaws.services.s3.{AmazonS3, model}
-import com.amazonaws.services.s3.transfer.model.UploadResult
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.transfer._
 import net.kemitix.s3thorp.aws.api.S3Action.UploadS3Action
 import net.kemitix.s3thorp.aws.api.UploadProgressListener
 import net.kemitix.s3thorp.core.KeyGenerator.generateKey
-import net.kemitix.s3thorp.core.{MD5HashGenerator, Resource}
+import net.kemitix.s3thorp.core.Resource
 import net.kemitix.s3thorp.domain._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.FunSpec
@@ -26,7 +22,6 @@ class S3ClientTransferManagerSuite
   implicit private val logInfo: Int => String => Unit = l => m => ()
   implicit private val logWarn: String => Unit = w => ()
   private val fileToKey = generateKey(config.source, config.prefix) _
-  private val fileToHash = (file: File) => MD5HashGenerator.md5File(file)
   val lastModified = LastModified(Instant.now())
 
   describe("S3ClientMultiPartTransferManagerSuite") {
@@ -34,7 +29,7 @@ class S3ClientTransferManagerSuite
       val transferManager = stub[TransferManager]
       val uploader = new S3ClientTransferManager(transferManager)
       describe("small-file") {
-        val smallFile = LocalFile.resolve("small-file", MD5Hash("the-hash"), source, fileToKey, fileToHash)
+        val smallFile = LocalFile.resolve("small-file", MD5Hash("the-hash"), source, fileToKey)
         it("should be a small-file") {
           assert(smallFile.file.length < 5 * 1024 * 1024)
         }
@@ -43,7 +38,7 @@ class S3ClientTransferManagerSuite
         }
       }
       describe("big-file") {
-        val bigFile = LocalFile.resolve("big-file", MD5Hash("the-hash"), source, fileToKey, fileToHash)
+        val bigFile = LocalFile.resolve("big-file", MD5Hash("the-hash"), source, fileToKey)
         it("should be a big-file") {
           assert(bigFile.file.length > 5 * 1024 * 1024)
         }
@@ -60,7 +55,7 @@ class S3ClientTransferManagerSuite
       // dies when putObject is called
       val returnedKey = RemoteKey("returned-key")
       val returnedHash = MD5Hash("returned-hash")
-      val bigFile = LocalFile.resolve("small-file", MD5Hash("the-hash"), source, fileToKey, fileToHash)
+      val bigFile = LocalFile.resolve("small-file", MD5Hash("the-hash"), source, fileToKey)
       val progressListener = new UploadProgressListener(bigFile)
       val amazonS3 = mock[AmazonS3]
       val amazonS3TransferManager = TransferManagerBuilder.standard().withS3Client(amazonS3).build

--- a/core/src/main/scala/net.kemitix.s3thorp.core/LocalFileStream.scala
+++ b/core/src/main/scala/net.kemitix.s3thorp.core/LocalFileStream.scala
@@ -2,34 +2,56 @@ package net.kemitix.s3thorp.core
 
 import java.io.File
 
+import cats.effect.IO
 import net.kemitix.s3thorp.core.KeyGenerator.generateKey
 import net.kemitix.s3thorp.domain.{Config, LocalFile, MD5Hash}
 
 object LocalFileStream {
 
   def findFiles(file: File,
-                md5HashGenerator: File => MD5Hash,
+                md5HashGenerator: File => IO[MD5Hash],
                 info: Int => String => Unit)
-               (implicit c: Config): Stream[LocalFile] = {
-    def loop(file: File): Stream[LocalFile] = {
-      info(2)(s"- Entering: $file")
-      val files = for {
-        f <- dirPaths(file)
-          .filter { f => f.isDirectory || c.filters.forall { filter => filter isIncluded f.toPath } }
-          .filter { f => c.excludes.forall { exclude => exclude isIncluded f.toPath } }
-        fs <- recurseIntoSubDirectories(f)
-      } yield fs
-      info(5)(s"-  Leaving: $file")
-      files
+               (implicit c: Config): IO[Stream[LocalFile]] = {
+
+    def loop(file: File): IO[Stream[LocalFile]] = {
+
+      def dirPaths(file: File): IO[Stream[File]] =
+        IO {
+          Option(file.listFiles)
+            .getOrElse(throw new IllegalArgumentException(s"Directory not found $file"))
+        }
+          .map(fs =>
+            Stream(fs: _*)
+              .filter(isIncluded))
+
+      def recurseIntoSubDirectories(file: File)(implicit c: Config): IO[Stream[LocalFile]] =
+        file match {
+          case f if f.isDirectory => loop(file)
+          case _ => for(hash <- md5HashGenerator(file))
+            yield Stream(LocalFile(file, c.source, hash, generateKey(c.source, c.prefix)))
+        }
+
+      def filterIsIncluded(f: File): Boolean =
+        f.isDirectory || c.filters.forall { filter => filter isIncluded f.toPath }
+
+      def excludeIsIncluded(f: File): Boolean =
+        c.excludes.forall { exclude => exclude isIncluded f.toPath }
+
+      def isIncluded(f: File): Boolean =
+        filterIsIncluded(f) && excludeIsIncluded(f)
+
+      def recurse(fs: Stream[File]): IO[Stream[LocalFile]] =
+        fs.foldLeft(IO.pure(Stream.empty[LocalFile]))((acc, f) =>
+          recurseIntoSubDirectories(f)
+            .flatMap(lfs => acc.map(s => s ++ lfs)))
+
+      for {
+        _ <- IO(info(2)(s"- Entering: $file"))
+        fs <- dirPaths(file)
+        lfs <- recurse(fs)
+        _ <- IO(info(5)(s"- Leaving : $file"))
+      } yield lfs
     }
-
-    def dirPaths(file: File): Stream[File] =
-      Option(file.listFiles)
-        .getOrElse(throw new IllegalArgumentException(s"Directory not found $file")).toStream
-
-    def recurseIntoSubDirectories(file: File)(implicit c: Config): Stream[LocalFile] =
-      if (file.isDirectory) loop(file)
-      else Stream(LocalFile(file, c.source, generateKey(c.source, c.prefix), md5HashGenerator))
 
     loop(file)
   }

--- a/core/src/main/scala/net.kemitix.s3thorp.core/MD5HashGenerator.scala
+++ b/core/src/main/scala/net.kemitix.s3thorp.core/MD5HashGenerator.scala
@@ -3,29 +3,42 @@ package net.kemitix.s3thorp.core
 import java.io.{File, FileInputStream}
 import java.security.MessageDigest
 
+import cats.effect.IO
 import net.kemitix.s3thorp.domain.MD5Hash
 
 object MD5HashGenerator {
 
   def md5File(file: File)
-             (implicit info: Int => String => Unit): MD5Hash =  {
-    val hash = md5FilePart(file, 0, file.length)
-    hash
-  }
+             (implicit info: Int => String => Unit): IO[MD5Hash] =
+    md5FilePart(file, 0, file.length)
 
   def md5FilePart(file: File,
                   offset: Long,
                   size: Long)
-                 (implicit info: Int => String => Unit): MD5Hash = {
-    info(5)(s"md5:reading:offset $offset:size $size:$file")
-    val fis = new FileInputStream(file)
-    fis skip offset
+                 (implicit info: Int => String => Unit): IO[MD5Hash] = {
     val buffer = new Array[Byte](size.toInt)
-    fis read buffer
-    val hash = md5PartBody(buffer)
-    info(5)(s"md5:generated:${hash.hash}")
-    fis.close
-    hash
+
+    def readIntoBuffer = {
+      fis: FileInputStream =>
+        IO {
+          fis skip offset
+          fis read buffer
+          fis
+        }
+    }
+
+    def closeFile = {fis: FileInputStream => IO(fis.close())}
+
+    def openFile = IO(new FileInputStream(file))
+
+    def readFile = openFile.bracket(readIntoBuffer)(closeFile)
+
+    for {
+      _ <- IO(info(5)(s"md5:reading:offset $offset:size $size:$file"))
+      _ <- readFile
+      hash = md5PartBody(buffer)
+      _ <- IO (info(5)(s"md5:generated:${hash.hash}"))
+    } yield hash
   }
 
   def md5PartBody(partBody: Array[Byte]): MD5Hash = {

--- a/core/src/main/scala/net.kemitix.s3thorp.core/S3MetaDataEnricher.scala
+++ b/core/src/main/scala/net.kemitix.s3thorp.core/S3MetaDataEnricher.scala
@@ -6,12 +6,11 @@ object S3MetaDataEnricher {
 
   def getMetadata(localFile: LocalFile,
                   s3ObjectsData: S3ObjectsData)
-                 (implicit c: Config): Stream[S3MetaData] = {
+                 (implicit c: Config): S3MetaData = {
     val (keyMatches, hashMatches) = getS3Status(localFile, s3ObjectsData)
-    Stream(
-      S3MetaData(localFile,
-        matchByKey = keyMatches map { hm => RemoteMetaData(localFile.remoteKey, hm.hash, hm.modified) },
-        matchByHash = hashMatches map { km => RemoteMetaData(km.key, localFile.hash, km.modified) }))
+    S3MetaData(localFile,
+      matchByKey = keyMatches map { hm => RemoteMetaData(localFile.remoteKey, hm.hash, hm.modified) },
+      matchByHash = hashMatches map { km => RemoteMetaData(km.key, localFile.hash, km.modified) })
   }
 
   def getS3Status(localFile: LocalFile,

--- a/core/src/test/scala/net/kemitix/s3thorp/core/ActionGeneratorSuite.scala
+++ b/core/src/test/scala/net/kemitix/s3thorp/core/ActionGeneratorSuite.scala
@@ -1,6 +1,5 @@
 package net.kemitix.s3thorp.core
 
-import java.io.File
 import java.time.Instant
 
 import net.kemitix.s3thorp.core.Action.{DoNothing, ToCopy, ToUpload}
@@ -16,7 +15,6 @@ class ActionGeneratorSuite
   implicit private val config: Config = Config(bucket, prefix, source = source)
   implicit private val logInfo: Int => String => Unit = l => i => ()
   private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
-  private val fileToHash = (file: File) => MD5HashGenerator.md5File(file)
   val lastModified = LastModified(Instant.now())
 
     describe("create actions") {
@@ -25,7 +23,7 @@ class ActionGeneratorSuite
 
       describe("#1 local exists, remote exists, remote matches - do nothing") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", theHash, source, fileToKey, fileToHash)
+        val theFile = LocalFile.resolve("the-file", theHash, source, fileToKey)
         val theRemoteMetadata = RemoteMetaData(theFile.remoteKey, theHash, lastModified)
         val input = S3MetaData(theFile, // local exists
           matchByHash = Set(theRemoteMetadata), // remote matches
@@ -39,7 +37,7 @@ class ActionGeneratorSuite
       }
       describe("#2 local exists, remote is missing, other matches - copy") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", theHash, source, fileToKey, fileToHash)
+        val theFile = LocalFile.resolve("the-file", theHash, source, fileToKey)
         val theRemoteKey = theFile.remoteKey
         val otherRemoteKey = prefix.resolve("other-key")
         val otherRemoteMetadata = RemoteMetaData(otherRemoteKey, theHash, lastModified)
@@ -54,7 +52,7 @@ class ActionGeneratorSuite
       }
       describe("#3 local exists, remote is missing, other no matches - upload") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", theHash, source, fileToKey, fileToHash)
+        val theFile = LocalFile.resolve("the-file", theHash, source, fileToKey)
         val input = S3MetaData(theFile, // local exists
           matchByHash = Set.empty, // other no matches
           matchByKey = None) // remote is missing
@@ -66,7 +64,7 @@ class ActionGeneratorSuite
       }
       describe("#4 local exists, remote exists, remote no match, other matches - copy") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", theHash, source, fileToKey, fileToHash)
+        val theFile = LocalFile.resolve("the-file", theHash, source, fileToKey)
         val theRemoteKey = theFile.remoteKey
         val oldHash = MD5Hash("old-hash")
         val otherRemoteKey = prefix.resolve("other-key")
@@ -85,7 +83,7 @@ class ActionGeneratorSuite
       }
       describe("#5 local exists, remote exists, remote no match, other no matches - upload") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", theHash, source, fileToKey, fileToHash)
+        val theFile = LocalFile.resolve("the-file", theHash, source, fileToKey)
         val theRemoteKey = theFile.remoteKey
         val oldHash = MD5Hash("old-hash")
         val theRemoteMetadata = RemoteMetaData(theRemoteKey, oldHash, lastModified)

--- a/core/src/test/scala/net/kemitix/s3thorp/core/LocalFileStreamSuite.scala
+++ b/core/src/test/scala/net/kemitix/s3thorp/core/LocalFileStreamSuite.scala
@@ -2,6 +2,7 @@ package net.kemitix.s3thorp.core
 
 import java.io.File
 
+import cats.effect.IO
 import net.kemitix.s3thorp.domain.{Config, LocalFile, MD5Hash}
 import org.scalatest.FunSpec
 
@@ -10,12 +11,12 @@ class LocalFileStreamSuite extends FunSpec {
   val uploadResource = Resource(this, "upload")
   val config: Config = Config(source = uploadResource)
   implicit private val logInfo: Int => String => Unit = l => i => ()
-  val md5HashGenerator: File => MD5Hash = file => MD5HashGenerator.md5File(file)
+  val md5HashGenerator: File => IO[MD5Hash] = file => MD5HashGenerator.md5File(file)
 
   describe("findFiles") {
     it("should find all files") {
       val result: Set[String] =
-        LocalFileStream.findFiles(uploadResource, md5HashGenerator, logInfo)(config).toSet
+        LocalFileStream.findFiles(uploadResource, md5HashGenerator, logInfo)(config).unsafeRunSync.toSet
           .map { x: LocalFile => x.relative.toString }
       assertResult(Set("subdir/leaf-file", "root-file"))(result)
     }

--- a/core/src/test/scala/net/kemitix/s3thorp/core/MD5HashData.scala
+++ b/core/src/test/scala/net/kemitix/s3thorp/core/MD5HashData.scala
@@ -1,0 +1,11 @@
+package net.kemitix.s3thorp.core
+
+import net.kemitix.s3thorp.domain.MD5Hash
+
+object MD5HashData {
+
+  def rootHash = MD5Hash("a3a6ac11a0eb577b81b3bb5c95cc8a6e")
+
+  def leafHash = MD5Hash("208386a650bdec61cfcd7bd8dcb6b542")
+
+}

--- a/core/src/test/scala/net/kemitix/s3thorp/core/MD5HashGeneratorTest.scala
+++ b/core/src/test/scala/net/kemitix/s3thorp/core/MD5HashGeneratorTest.scala
@@ -2,6 +2,7 @@ package net.kemitix.s3thorp.core
 
 import java.nio.file.Files
 
+import net.kemitix.s3thorp.core.MD5HashData.rootHash
 import net.kemitix.s3thorp.domain.{Bucket, Config, MD5Hash, RemoteKey}
 import org.scalatest.FunSpec
 
@@ -15,25 +16,23 @@ class MD5HashGeneratorTest extends FunSpec {
     describe("read a small file (smaller than buffer)") {
       val file = Resource(this, "upload/root-file")
       it("should generate the correct hash") {
-        val expected = MD5Hash("a3a6ac11a0eb577b81b3bb5c95cc8a6e")
-        val result = MD5HashGenerator.md5File(file)
-        assertResult(expected)(result)
+        val result = MD5HashGenerator.md5File(file).unsafeRunSync
+        assertResult(rootHash)(result)
       }
     }
     describe("read a buffer") {
       val file = Resource(this, "upload/root-file")
       val buffer: Array[Byte] = Files.readAllBytes(file.toPath)
       it("should generate the correct hash") {
-        val expected = MD5Hash("a3a6ac11a0eb577b81b3bb5c95cc8a6e")
         val result = MD5HashGenerator.md5PartBody(buffer)
-        assertResult(expected)(result)
+        assertResult(rootHash)(result)
       }
     }
     describe("read a large file (bigger than buffer)") {
       val file = Resource(this, "big-file")
       it("should generate the correct hash") {
         val expected = MD5Hash("b1ab1f7680138e6db7309200584e35d8")
-        val result = MD5HashGenerator.md5File(file)
+        val result = MD5HashGenerator.md5File(file).unsafeRunSync
         assertResult(expected)(result)
       }
     }
@@ -44,14 +43,14 @@ class MD5HashGeneratorTest extends FunSpec {
       describe("when starting at the beginning of the file") {
         it("should generate the correct hash") {
           val expected = MD5Hash("aadf0d266cefe0fcdb241a51798d74b3")
-          val result = MD5HashGenerator.md5FilePart(file, 0, halfFileLength)
+          val result = MD5HashGenerator.md5FilePart(file, 0, halfFileLength).unsafeRunSync
           assertResult(expected)(result)
         }
       }
       describe("when starting in the middle of the file") {
         it("should generate the correct hash") {
           val expected = MD5Hash("16e08d53ca36e729d808fd5e4f7e35dc")
-          val result = MD5HashGenerator.md5FilePart(file, halfFileLength, halfFileLength)
+          val result = MD5HashGenerator.md5FilePart(file, halfFileLength, halfFileLength).unsafeRunSync
           assertResult(expected)(result)
         }
       }

--- a/domain/src/main/scala/net/kemitix/s3thorp/domain/LocalFile.scala
+++ b/domain/src/main/scala/net/kemitix/s3thorp/domain/LocalFile.scala
@@ -3,18 +3,9 @@ package net.kemitix.s3thorp.domain
 import java.io.File
 import java.nio.file.Path
 
-final case class LocalFile(
-  file: File,
-  source: File,
-  keyGenerator: File => RemoteKey,
-  md5HashGenerator: File => MD5Hash,
-  suppliedHash: Option[MD5Hash] = None) {
+final case class LocalFile(file: File, source: File, hash: MD5Hash, keyGenerator: File => RemoteKey) {
 
   require(!file.isDirectory, s"LocalFile must not be a directory: $file")
-
-  private lazy val myhash = suppliedHash.getOrElse(md5HashGenerator(file))
-
-  def hash: MD5Hash = myhash
 
   // the equivalent location of the file on S3
   def remoteKey: RemoteKey = keyGenerator(file)
@@ -28,14 +19,10 @@ final case class LocalFile(
 
 object LocalFile {
   def resolve(path: String,
-              myHash: MD5Hash,
+              md5Hash: MD5Hash,
               source: File,
-              fileToKey: File => RemoteKey,
-              fileToHash: File => MD5Hash): LocalFile =
-    LocalFile(
-      file = source.toPath.resolve(path).toFile,
-      source = source,
-      keyGenerator = fileToKey,
-      md5HashGenerator = fileToHash,
-      suppliedHash = Some(myHash))
+              fileToKey: File => RemoteKey): LocalFile = {
+    val file = source.toPath.resolve(path).toFile
+    LocalFile(file, source, md5Hash, fileToKey)
+  }
 }


### PR DESCRIPTION
This required that `LocalFile` in the domain module no longer be supplied with a function to convert a `File` into an `MD5Hash`. Because such a function requires reading the file it now must use `IO`, which we don't allow in the `domain` module.

Unfortunate ripple effects out to users of `MD5HashGenerator` and `LocalFile`.