### PR TITLE
Handle when a file is not found after initial scan

### DIFF
--- a/aws-lib/src/main/scala/net/kemitix/s3thorp/aws/lib/Uploader.scala
+++ b/aws-lib/src/main/scala/net/kemitix/s3thorp/aws/lib/Uploader.scala
@@ -24,13 +24,12 @@ class Uploader(transferManager: => AmazonTransferManager) {
              tryCount: Int,
              maxRetries: Int)
             (implicit info: Int => String => IO[Unit],
-             warn: String => IO[Unit]): IO[S3Action] = {
+             warn: String => IO[Unit]): IO[S3Action] =
     for {
       _ <- logMultiPartUploadStart(localFile, tryCount)
       result <- upload(localFile, bucket, uploadProgressListener)
       _ <- logMultiPartUploadFinished(localFile)
     } yield UploadS3Action(RemoteKey(result.getKey), MD5Hash(result.getETag))
-  }
 
   private def upload(localFile: LocalFile,
                      bucket: Bucket,
@@ -42,10 +41,9 @@ class Uploader(transferManager: => AmazonTransferManager) {
     IO(upload.waitForUploadResult)
   }
 
-  private def request(localFile: LocalFile, bucket: Bucket, listener: ProgressListener): PutObjectRequest = {
+  private def request(localFile: LocalFile, bucket: Bucket, listener: ProgressListener): PutObjectRequest =
     new PutObjectRequest(bucket.name, localFile.remoteKey.key, localFile.file)
       .withGeneralProgressListener(listener)
-  }
 
   private def progressListener(uploadProgressListener: UploadProgressListener) =
     new ProgressListener {

--- a/aws-lib/src/main/scala/net/kemitix/s3thorp/aws/lib/Uploader.scala
+++ b/aws-lib/src/main/scala/net/kemitix/s3thorp/aws/lib/Uploader.scala
@@ -37,8 +37,7 @@ class Uploader(transferManager: => AmazonTransferManager) {
                     ): IO[UploadResult] = {
     val listener = progressListener(uploadProgressListener)
     val putObjectRequest = request(localFile, bucket, listener)
-    val upload = transferManager.upload(putObjectRequest)
-    IO(upload.waitForUploadResult)
+    IO(transferManager.upload(putObjectRequest).waitForUploadResult)
   }
 
   private def request(localFile: LocalFile, bucket: Bucket, listener: ProgressListener): PutObjectRequest =

--- a/core/src/main/scala/net.kemitix.s3thorp.core/Counters.scala
+++ b/core/src/main/scala/net.kemitix.s3thorp.core/Counters.scala
@@ -2,4 +2,5 @@ package net.kemitix.s3thorp.core
 
 final case class Counters(uploaded: Int = 0,
                           deleted: Int = 0,
-                          copied: Int = 0)
+                          copied: Int = 0,
+                          errors: Int = 0)


### PR DESCRIPTION
During the initial scan of the source directory, a file may be found, but when it comes to uploading that file, if it has moved or been deleted, the following error happens:

```
[ ERROR] Unable to calculate MD5 hash: /home/pcampbell/org-mode/.git/index.sync-conflict-20190604-113505-7NJWXQ5 (No such file or directory)
com.amazonaws.SdkClientException: Unable to calculate MD5 hash: /home/pcampbell/org-mode/.git/index.sync-conflict-20190604-113505-7NJWXQ5 (No such file or directory)
        at com.amazonaws.services.s3.AmazonS3Client.getInputStream(AmazonS3Client.java:1852)
        at com.amazonaws.services.s3.AmazonS3Client.uploadObject(AmazonS3Client.java:1770)
        at com.amazonaws.services.s3.AmazonS3Client.putObject(AmazonS3Client.java:1749)
        at com.amazonaws.services.s3.transfer.internal.UploadCallable.uploadInOneChunk(UploadCallable.java:131)
        at com.amazonaws.services.s3.transfer.internal.UploadCallable.call(UploadCallable.java:123)
        at com.amazonaws.services.s3.transfer.internal.UploadMonitor.call(UploadMonitor.java:143)
        at com.amazonaws.services.s3.transfer.internal.UploadMonitor.call(UploadMonitor.java:48)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.FileNotFoundException: /home/pcampbell/org-mode/.git/index.sync-conflict-20190604-113505-7NJWXQ5 (No such file or directory)
        at java.io.FileInputStream.open0(Native Method)
        at java.io.FileInputStream.open(FileInputStream.java:195)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at com.amazonaws.util.Md5Utils.computeMD5Hash(Md5Utils.java:97)
        at com.amazonaws.util.Md5Utils.md5AsBase64(Md5Utils.java:104)
        at com.amazonaws.services.s3.AmazonS3Client.getInputStream(AmazonS3Client.java:1848)
        ... 10 more
```

Nete that the MD5Hash being calculated in the stacktrack is the SDK's version, not the S3Thorps version.