### PR TITLE
Error when calculating MD5Hash for large files

### DIFF
--- a/core/src/test/scala/net/kemitix/s3thorp/core/MD5HashGeneratorTest.scala
+++ b/core/src/test/scala/net/kemitix/s3thorp/core/MD5HashGeneratorTest.scala
@@ -21,39 +21,12 @@ class MD5HashGeneratorTest extends FunSpec {
         assertResult(rootHash)(result)
       }
     }
-    describe("read a buffer") {
-      val file = Resource(this, "upload/root-file")
-      val buffer: Array[Byte] = Files.readAllBytes(file.toPath)
-      it("should generate the correct hash") {
-        val result = MD5HashGenerator.md5PartBody(buffer)
-        assertResult(rootHash)(result)
-      }
-    }
     describe("read a large file (bigger than buffer)") {
       val file = Resource(this, "big-file")
       it("should generate the correct hash") {
         val expected = MD5Hash("b1ab1f7680138e6db7309200584e35d8")
         val result = MD5HashGenerator.md5File(file).unsafeRunSync
         assertResult(expected)(result)
-      }
-    }
-    describe("read part of a file") {
-      val file = Resource(this, "big-file")
-      val halfFileLength = file.length / 2
-      assertResult(file.length)(halfFileLength * 2)
-      describe("when starting at the beginning of the file") {
-        it("should generate the correct hash") {
-          val expected = MD5Hash("aadf0d266cefe0fcdb241a51798d74b3")
-          val result = MD5HashGenerator.md5FilePart(file, 0, halfFileLength).unsafeRunSync
-          assertResult(expected)(result)
-        }
-      }
-      describe("when starting in the middle of the file") {
-        it("should generate the correct hash") {
-          val expected = MD5Hash("16e08d53ca36e729d808fd5e4f7e35dc")
-          val result = MD5HashGenerator.md5FilePart(file, halfFileLength, halfFileLength).unsafeRunSync
-          assertResult(expected)(result)
-        }
       }
     }
 

--- a/domain/src/main/scala/net/kemitix/s3thorp/domain/SizeTranslation.scala
+++ b/domain/src/main/scala/net/kemitix/s3thorp/domain/SizeTranslation.scala
@@ -2,11 +2,15 @@ package net.kemitix.s3thorp.domain
 
 object SizeTranslation {
 
+  val kbLimit = 10240L
+  val mbLimit = kbLimit * 1024
+  val gbLimit = mbLimit * 1024
+
   def sizeInEnglish(length: Long): String =
-    length match {
-      case bytes if bytes > 1024 * 1024 * 1024 => s"${bytes / 1024 / 1024 /1024}Gb"
-      case bytes if bytes > 1024 * 1024 => s"${bytes / 1024 / 1024}Mb"
-      case bytes if bytes > 1024 => s"${bytes / 1024}Kb"
+    length.toDouble match {
+      case bytes if bytes > gbLimit => f"${bytes / 1024 / 1024 /1024}%.3fGb"
+      case bytes if bytes > mbLimit => f"${bytes / 1024 / 1024}%.2fMb"
+      case bytes if bytes > kbLimit => f"${bytes / 1024}%.0fKb"
       case bytes => s"${length}b"
     }
 

--- a/domain/src/test/scala/net/kemitix/s3thorp/domain/SizeTranslationTest.scala
+++ b/domain/src/test/scala/net/kemitix/s3thorp/domain/SizeTranslationTest.scala
@@ -1,0 +1,35 @@
+package net.kemitix.s3thorp.domain
+
+import org.scalatest.FunSpec
+
+class SizeTranslationTest extends FunSpec {
+
+  describe("sizeInEnglish") {
+    describe("when size is less the 1Kb") {
+      it("should in in bytes") {
+        assertResult("512b")(SizeTranslation.sizeInEnglish(512))
+      }
+    }
+    describe("when size is a less than 10Kb") {
+      it("should still be in bytes") {
+        assertResult("2000b")(SizeTranslation.sizeInEnglish(2000))
+      }
+    }
+    describe("when size is over 10Kb and less than 10Mb") {
+      it("should be in Kb with zero decimal places") {
+        assertResult("5468Kb")(SizeTranslation.sizeInEnglish(5599232))
+      }
+    }
+    describe("when size is over 10Mb and less than 10Gb") {
+      it("should be in Mb with two decimal place") {
+        assertResult("5468.17Mb")(SizeTranslation.sizeInEnglish(5733789833L))
+      }
+    }
+    describe("when size is over 10Gb") {
+      it("should be in Gb with three decimal place") {
+        assertResult("5468.168Gb")(SizeTranslation.sizeInEnglish(5871400857278L))
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
```
java.lang.OutOfMemoryError: Java heap space
        at net.kemitix.s3thorp.core.MD5HashGenerator$.md5FilePart(MD5HashGenerator.scala:19)
        at net.kemitix.s3thorp.core.MD5HashGenerator$.md5File(MD5HashGenerator.scala:13)
        at net.kemitix.s3thorp.cli.Main$.$anonfun$program$4(Main.scala:23)
        at net.kemitix.s3thorp.cli.Main$$$Lambda$3014/1578459121.apply(Unknown Source)
        at net.kemitix.s3thorp.core.LocalFileStream$.recurseIntoSubDirectories$1(LocalFileStream.scala:33)
        at net.kemitix.s3thorp.core.LocalFileStream$.$anonfun$findFiles$8(LocalFileStream.scala:39)
        at net.kemitix.s3thorp.core.LocalFileStream$$$Lambda$3085/354416518.apply(Unknown Source)
        at scala.collection.immutable.Stream.foldLeft(Stream.scala:549)
        at net.kemitix.s3thorp.core.LocalFileStream$.recurse$1(LocalFileStream.scala:38)
        at net.kemitix.s3thorp.core.LocalFileStream$.$anonfun$findFiles$13(LocalFileStream.scala:45)
        at net.kemitix.s3thorp.core.LocalFileStream$$$Lambda$3078/503399306.apply(Unknown Source)
        at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:139)
        at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:355)
        at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:376)
        at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:316)
        at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:136)
        at cats.effect.internals.IORunLoop$.startCancelable(IORunLoop.scala:41)
        at cats.effect.internals.IOBracket$BracketStart.run(IOBracket.scala:86)
        at cats.effect.internals.Trampoline.cats$effect$internals$Trampoline$$immediateLoop(Trampoline.scala:70)
        at cats.effect.internals.Trampoline.startLoop(Trampoline.scala:36)
        at cats.effect.internals.TrampolineEC$JVMTrampoline.super$startLoop(TrampolineEC.scala:93)
        at cats.effect.internals.TrampolineEC$JVMTrampoline.$anonfun$startLoop$1(TrampolineEC.scala:93)
        at cats.effect.internals.TrampolineEC$JVMTrampoline$$Lambda$3009/103187531.apply$mcV$sp(Unknown Source)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
        at cats.effect.internals.TrampolineEC$JVMTrampoline.startLoop(TrampolineEC.scala:93)
        at cats.effect.internals.Trampoline.execute(Trampoline.scala:43)
        at cats.effect.internals.TrampolineEC.execute(TrampolineEC.scala:44)
        at cats.effect.internals.IOBracket$.$anonfun$guaranteeCase$1(IOBracket.scala:100)
        at cats.effect.internals.IOBracket$.$anonfun$guaranteeCase$1$adapted(IOBracket.scala:98)
        at cats.effect.internals.IOBracket$$$Lambda$2983/9730432.apply(Unknown Source)
        at cats.effect.internals.IORunLoop$RestartCallback.start(IORunLoop.scala:341)
```