### PR TITLE
Enable running outside of sbt

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,3 +40,14 @@ When considering a local file, the following table governs what should happen:
 | 5 | exists     | exists     | no match         | no matches         | upload              |
 | 6 | is missing | exists     | -                | -                  | delete              |
 |---+------------+------------+------------------+--------------------+---------------------|
+
+* Executable JAR
+
+To build as an executable jar, perform `sbt assembly`
+
+This will create the file
+`cli/target/scala-2.12/s3thorp-assembly-$VERSION.jar` (where $VERSION
+is substituted)
+
+Copy and rename this file as `s3thorp.jar` into the same directory as
+the `bin/s3throp` shell script.

--- a/bin/s3thorp
+++ b/bin/s3thorp
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+THORP_HOME=`dirname $0`
+eval `resize`
+java -jar $THORP_HOME/s3thorp.jar $*

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val commonSettings = Seq(
-  version := "0.1",
+  version := "DEV-SNAPSHOT",
   organization := "net.kemitix",
   scalaVersion := "2.12.8",
   test in assembly := {}

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,12 @@
+val commonSettings = Seq(
+  version := "0.1",
+  organization := "net.kemitix",
+  scalaVersion := "2.12.8",
+  test in assembly := {}
+)
+
 val applicationSettings = Seq(
   name := "s3thorp",
-  version := "0.1",
-  scalaVersion := "2.12.8"
 )
 val testDependencies = Seq(
   libraryDependencies ++= Seq(
@@ -39,23 +44,33 @@ val catsEffectsSettings = Seq(
 // cli -> aws-lib -> core -> aws-api -> domain
 
 lazy val cli = (project in file("cli"))
+  .settings(commonSettings)
+  .settings(mainClass in assembly := Some("net.kemitix.s3thorp.cli.Main"))
   .settings(applicationSettings)
   .aggregate(`aws-lib`, core, `aws-api`, domain)
   .settings(commandLineParsing)
   .dependsOn(`aws-lib`)
 
 lazy val `aws-lib` = (project in file("aws-lib"))
+  .settings(commonSettings)
+  .settings(assemblyJarName in assembly := "aws-lib.jar")
   .settings(awsSdkDependencies)
   .settings(testDependencies)
   .dependsOn(core)
 
 lazy val core = (project in file("core"))
+  .settings(commonSettings)
+  .settings(assemblyJarName in assembly := "core.jar")
   .settings(testDependencies)
   .dependsOn(`aws-api`)
 
 lazy val `aws-api` = (project in file("aws-api"))
+  .settings(commonSettings)
+  .settings(assemblyJarName in assembly := "aws-api.jar")
   .settings(catsEffectsSettings)
   .dependsOn(domain)
 
 lazy val domain = (project in file("domain"))
+  .settings(commonSettings)
+  .settings(assemblyJarName in assembly := "domain.jar")
   .settings(testDependencies)

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")


### PR DESCRIPTION
Currently, the only way to execute `s3thorp` is within `sbt`. While the ideal would be to create a native binary, e.g. #15 , a single Jar file that can be executed with a JDK would be acceptable.