### PR TITLE
Better error message when source is not found

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val cli = (project in file("cli"))
   .settings(catsEffectsSettings)
   .aggregate(`aws-lib`, core, `aws-api`, domain)
   .settings(commandLineParsing)
+  .settings(testDependencies)
   .dependsOn(`aws-lib`)
 
 lazy val `aws-lib` = (project in file("aws-lib"))

--- a/cli/src/main/scala/net/kemitix/s3thorp/cli/ParseArgs.scala
+++ b/cli/src/main/scala/net/kemitix/s3thorp/cli/ParseArgs.scala
@@ -1,5 +1,6 @@
 package net.kemitix.s3thorp.cli
 
+import java.io.File
 import java.nio.file.Paths
 
 import net.kemitix.s3thorp.domain.Filter.{Exclude, Include}
@@ -16,6 +17,7 @@ object ParseArgs {
       head("s3thorp"),
       opt[String]('s', "source")
         .action((str, c) => c.copy(source = Paths.get(str).toFile))
+        .validate(s => if (new File(s).isDirectory) Right(()) else Left("Source is not a directory"))
         .required()
         .text("Source directory to sync to S3"),
       opt[String]('b', "bucket")

--- a/cli/src/test/scala/net/kemitix/s3thorp/cli/ParseArgsTest.scala
+++ b/cli/src/test/scala/net/kemitix/s3thorp/cli/ParseArgsTest.scala
@@ -1,0 +1,53 @@
+package net.kemitix.s3thorp.cli
+
+import net.kemitix.s3thorp.core.Resource
+import net.kemitix.s3thorp.domain.{Bucket, Config}
+import org.scalatest.FunSpec
+
+import scala.util.Try
+
+class ParseArgsTest extends FunSpec {
+
+  val source = Resource(this, "")
+  val defaultConfig: Config = Config(source = source)
+
+  describe("parse - source") {
+    def invokeWithSource(path: String) = {
+      ParseArgs(List("--source", path, "--bucket", "bucket"), defaultConfig)
+    }
+
+    describe("when source is a directory") {
+      val result = invokeWithSource(pathTo("."))
+      it("should succeed") {
+        assert(result.isDefined)
+      }
+    }
+    describe("when source is a file") {
+      val result = invokeWithSource(pathTo("ParseArgs.class"))
+      it("should fail") {
+        assert(result.isEmpty)
+      }
+    }
+    describe("when source is not found") {
+      val result = invokeWithSource(pathTo("not-found"))
+      it("should fail") {
+        assert(result.isEmpty)
+      }
+    }
+    describe("when source is a relative path to a directory") {
+      it("should succeed") {pending}
+    }
+    describe("when source is a relative path to a file") {
+      it("should fail") {pending}
+    }
+    describe("when source is a relative path to a missing path") {
+      it("should fail") {pending}
+    }
+  }
+
+  private def pathTo(value: String): String =
+    Try(Resource(this, value))
+      .map(_.getCanonicalPath)
+      .getOrElse("[not-found]")
+
+}


### PR DESCRIPTION
An ugly stack trace is thrown if the source path isn't found.